### PR TITLE
Exclude the CPT from search!

### DIFF
--- a/classes/ecp/WP_Custom_Post.php
+++ b/classes/ecp/WP_Custom_Post.php
@@ -33,6 +33,7 @@ abstract class WP_Custom_Post {
 				'_builtin' => false, // It's a custom post type, not built in
 				'capability_type' => 'post',
 				'hierarchical' => false,
+				'exclude_from_search' => true, //dont make them searchable!
 				'rewrite' => array("slug" => $this->_name), // Permalinks
 				'query_var' => $this->_name, // This goes to the WP_Query schema
 				'supports' => array('title'/*,'custom-fields'*/), // Let's use custom fields for debugging purposes only


### PR DESCRIPTION
We need the new custom post tpe to be excluded from search since they don't provide content on their own but only in connection with category pages. Also the plugin needs a maintenance update! 

Thanks in advance :)